### PR TITLE
Bump parallel-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "minimist": "~0.2.0",
-    "parallel-stream": "0.1.2",
+    "parallel-stream": "0.1.4",
     "progress-stream": "~0.5.x",
     "queue-async": "~1.0.7",
     "sphericalmercator": "~1.0.1"


### PR DESCRIPTION
Parallel-stream switch to basic-queue for more reliability in some situations where millions of tiles are being copied.