### PR TITLE
Copy retry

### DIFF
--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -34,6 +34,7 @@ if (!argv._[0]) {
     console.log('  --maxzoom=[number]');
     console.log('  --parts=[number]');
     console.log('  --part=[number]');
+    console.log('  --retry=[number]');
     process.exit(1);
 }
 
@@ -46,6 +47,7 @@ argv.maxzoom = argv.maxzoom !== undefined ? parseInt(argv.maxzoom,10) : undefine
 argv.withoutprogress = argv.withoutprogress ? true : false;
 argv.parts = isNumeric(argv.parts) ? argv.parts : undefined;
 argv.part = isNumeric(argv.part) ? argv.part : undefined;
+argv.retry = isNumeric(argv.retry) ? parseInt(argv.retry,10) : undefined;
 
 if (argv.scheme !== 'pyramid' && argv.scheme !== 'scanline' && argv.scheme !== 'list') {
     console.warn('scheme must be one of pyramid, scanline, list');
@@ -70,7 +72,8 @@ function copy() {
         type:argv.scheme,
         minzoom:argv.minzoom,
         maxzoom:argv.maxzoom,
-        bounds:argv.bounds
+        bounds:argv.bounds,
+        retry:argv.retry
     };
 
     if (!argv.withoutprogress && dsturi) options.progress = report;

--- a/lib/stream-list.js
+++ b/lib/stream-list.js
@@ -5,6 +5,7 @@ var Info = require('./stream-util').Info;
 var isEmpty = require('./stream-util').isEmpty;
 var multiread = require('./stream-util').multiread;
 var setConcurrency = require('./stream-util').setConcurrency;
+var getTileRetry = require('./stream-util').getTileRetry;
 var stream = require('stream');
 var util = require('util');
 var queue = require('queue-async');
@@ -20,6 +21,7 @@ function List(source, options) {
     this.stats = new Stats();
     this.length = 0;
     this.job = options.job || false;
+    this.retry = options.retry || 0;
 
     // Determine when the writable stream is finished so the
     // readable stream can stop waiting.
@@ -79,7 +81,7 @@ List.prototype._transform = function(obj, encoding, callback) {
         if (stream.job && zxy.x % stream.job.total !== stream.job.num)
             return skip();
 
-        stream.source.getTile(zxy.z, zxy.x, zxy.y, function(err, buffer) {
+        getTileRetry(stream.source, zxy.z, zxy.x, zxy.y, stream.retry, function(err, buffer) {
             if (err && !(/does not exist$/).test(err.message)) {
                 done(err);
             } else if (err || isEmpty(buffer)) {

--- a/lib/stream-put.js
+++ b/lib/stream-put.js
@@ -58,7 +58,7 @@ Put.prototype._write = function(obj, encoding, callback) {
     multiwrite(stream, callback, function write(done) {
         if (obj instanceof Tile) {
             stream.stats.ops++;
-            putTileRetry(stream.source, obj.z, obj.x, obj.y, obj.buffer, stream.retry, function(err) {
+            return putTileRetry(stream.source, obj.z, obj.x, obj.y, obj.buffer, stream.retry, function(err) {
                 if (err) return done(err);
                 stream.stats.done++;
                 done();

--- a/lib/stream-put.js
+++ b/lib/stream-put.js
@@ -4,6 +4,7 @@ var Info = require('./stream-util').Info;
 var stream = require('stream');
 var util = require('util');
 var multiwrite = require('./stream-util').multiwrite;
+var putTileRetry = require('./stream-util').putTileRetry;
 
 module.exports = Put;
 util.inherits(Put, stream.Writable);
@@ -11,6 +12,7 @@ util.inherits(Put, stream.Writable);
 function Put(source, options) {
     if (!source) throw new TypeError('Tilesource required');
     this.source = source;
+    this.retry = options.retry || 0;
 
     // If source has no startWriting function, skip lazy initialization step.
     this.startWriting = source.startWriting === undefined;
@@ -56,7 +58,7 @@ Put.prototype._write = function(obj, encoding, callback) {
     multiwrite(stream, callback, function write(done) {
         if (obj instanceof Tile) {
             stream.stats.ops++;
-            return stream.source.putTile(obj.z, obj.x, obj.y, obj.buffer, function(err) {
+            putTileRetry(stream.source, obj.z, obj.x, obj.y, obj.buffer, stream.retry, function(err) {
                 if (err) return done(err);
                 stream.stats.done++;
                 done();

--- a/lib/stream-pyramid.js
+++ b/lib/stream-pyramid.js
@@ -6,6 +6,7 @@ var isEmpty = require('./stream-util').isEmpty;
 var addChildren = require('./stream-util').addChildren;
 var sumChildren = require('./stream-util').sumChildren;
 var multiread = require('./stream-util').multiread;
+var getTileRetry = require('./stream-util').getTileRetry;
 var stream = require('stream');
 var util = require('util');
 
@@ -35,6 +36,7 @@ function Pyramid(source, options) {
     this.stats = new Stats();
     this.length = 0;
     this.job = options.job || false;
+    this.retry = options.retry || 0;
 
     stream.Readable.call(this, { objectMode: true });
 }
@@ -98,7 +100,7 @@ Pyramid.prototype._read = function(size) {
             y = queued.y;
             stream.pending++;
             stream.stats.ops++;
-            stream.source.getTile(z, x, y, done);
+            getTileRetry(stream.source, z, x, y, stream.retry, done);
             // Do not repeat buffers in a pyramid fashion for now as
             // there are possible false positives in upstream solid
             // detection.
@@ -106,7 +108,7 @@ Pyramid.prototype._read = function(size) {
             // if (queued.buffer) {
             //     done(null, queued.buffer);
             // } else {
-            //     stream.source.getTile(z, x, y, done);
+            //     getTileRetry(stream.source, z, x, y, stream.retry, done);
             // }
             return true;
         } else if (stream.cursor) {
@@ -116,7 +118,7 @@ Pyramid.prototype._read = function(size) {
             nextShallow(stream);
             stream.pending++;
             stream.stats.ops++;
-            stream.source.getTile(z, x, y, done);
+            getTileRetry(stream.source, z, x, y, stream.retry, done);
             return true;
         } else {
             return push(null) && false;

--- a/lib/stream-scanline.js
+++ b/lib/stream-scanline.js
@@ -4,6 +4,7 @@ var Tile = require('./stream-util').Tile;
 var Info = require('./stream-util').Info;
 var isEmpty = require('./stream-util').isEmpty;
 var multiread = require('./stream-util').multiread;
+var getTileRetry = require('./stream-util').getTileRetry;
 var stream = require('stream');
 var util = require('util');
 
@@ -31,6 +32,7 @@ function Scanline(source, options) {
     this.cursor = undefined;
     this.length = 0;
     this.job = options.job || false;
+    this.retry = options.retry || 0;
 
     stream.Readable.call(this, { objectMode: true });
 }
@@ -88,7 +90,7 @@ Scanline.prototype._read = function(size) {
         if (stream.job && x % stream.job.total !== stream.job.num)
             return skip();
 
-        stream.source.getTile(z, x, y, function(err, buffer) {
+        getTileRetry(stream.source, z, x, y, stream.retry, function(err, buffer) {
             if (err && !(/does not exist$/).test(err.message)) {
                 stream.emit('error', err);
             } else if (err || isEmpty(buffer)) {

--- a/lib/stream-util.js
+++ b/lib/stream-util.js
@@ -17,6 +17,7 @@ module.exports.deserialize = deserialize;
 module.exports.serialHeader = 'JSONBREAKFASTTIME';
 module.exports.getTileRetry = getTileRetry;
 module.exports.putTileRetry = putTileRetry;
+module.exports.retryBackoff = 1000;
 
 function DeserializationError(msg) {
     this.message = msg;
@@ -214,10 +215,10 @@ function setConcurrency(c) {
 function getTileRetry(source, z, x, y, tries, callback) {
     tries = typeof tries === 'number' ? { max:tries, num:0 } : tries;
     source.getTile(z, x, y, function(err, tile, headers) {
-        if (err && ++tries.num < tries.max) {
+        if (err && tries.num++ < tries.max) {
             setTimeout(function() {
                 getTileRetry(source, z, x, y, tries, callback);
-            }, Math.pow(2, tries.num) * 1000);
+            }, Math.pow(2, tries.num) * module.exports.retryBackoff);
         } else {
             callback.apply(this, arguments);
         }
@@ -227,10 +228,10 @@ function getTileRetry(source, z, x, y, tries, callback) {
 function putTileRetry(source, z, x, y, data, tries, callback) {
     tries = typeof tries === 'number' ? { max:tries, num:0 } : tries;
     source.putTile(z, x, y, data, function(err) {
-        if (err && ++tries.num < tries.max) {
+        if (err && tries.num++ < tries.max) {
             setTimeout(function() {
                 putTileRetry(source, z, x, y, data, tries, callback);
-            }, Math.pow(2, tries.num) * 1000);
+            }, Math.pow(2, tries.num) * module.exports.retryBackoff);
         } else {
             callback.apply(this, arguments);
         }

--- a/lib/stream-util.js
+++ b/lib/stream-util.js
@@ -15,6 +15,8 @@ module.exports.setConcurrency = setConcurrency;
 module.exports.serialize = serialize;
 module.exports.deserialize = deserialize;
 module.exports.serialHeader = 'JSONBREAKFASTTIME';
+module.exports.getTileRetry = getTileRetry;
+module.exports.putTileRetry = putTileRetry;
 
 function DeserializationError(msg) {
     this.message = msg;
@@ -208,3 +210,30 @@ function setConcurrency(c) {
     if (c) concurrency = c;
     return concurrency;
 }
+
+function getTileRetry(source, z, x, y, tries, callback) {
+    tries = typeof tries === 'number' ? { max:tries, num:0 } : tries;
+    source.getTile(z, x, y, function(err, tile, headers) {
+        if (err && ++tries.num < tries.max) {
+            setTimeout(function() {
+                getTileRetry(source, z, x, y, tries, callback);
+            }, Math.pow(2, tries.num) * 1000);
+        } else {
+            callback.apply(this, arguments);
+        }
+    });
+}
+
+function putTileRetry(source, z, x, y, data, tries, callback) {
+    tries = typeof tries === 'number' ? { max:tries, num:0 } : tries;
+    source.putTile(z, x, y, data, function(err) {
+        if (err && ++tries.num < tries.max) {
+            setTimeout(function() {
+                putTileRetry(source, z, x, y, data, tries, callback);
+            }, Math.pow(2, tries.num) * 1000);
+        } else {
+            callback.apply(this, arguments);
+        }
+    });
+}
+

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -349,7 +349,7 @@ tilelive.copy = function(src, dst, options, callback) {
 
         // Copy
         var get = tilelive.createReadStream(src, opts);
-        var put = tilelive.createWriteStream(dst);
+        var put = tilelive.createWriteStream(dst, {retry:opts.retry});
 
         var hasErrored = false;
         function handleError(err) {

--- a/test/stream-pyramid.test.js
+++ b/test/stream-pyramid.test.js
@@ -144,3 +144,31 @@ test('pyramid: split into jobs', function(t) {
         });
     }
 });
+
+test('pyramid: err + no retry', function(assert) {
+    var get = tilelive.createReadStream(new Timedsource({fail:1}), {type:'pyramid'});
+    var put = tilelive.createWriteStream(new Timedsource({}));
+    var errored = false;
+    get.on('error', function(err) {
+        if (errored) return;
+        assert.equal(err.toString(), 'Error: Fatal', 'errors');
+        errored = true;
+        assert.end();
+    });
+    get.pipe(put);
+});
+
+test('pyramid: err + retry', function(assert) {
+    require('../lib/stream-util').retryBackoff = 1;
+    var get = tilelive.createReadStream(new Timedsource({fail:1}), {type:'pyramid', retry:1});
+    var put = tilelive.createWriteStream(new Timedsource({}));
+    get.on('error', function(err) { assert.ifError(err); });
+    put.on('error', function(err) { assert.ifError(err); });
+    put.on('stop', function() {
+        require('../lib/stream-util').retryBackoff = 1000;
+        assert.deepEqual(get.stats, { ops:45, total: 85, skipped: 42, done: 85 });
+        assert.end();
+    });
+    get.pipe(put);
+});
+

--- a/test/stream-util.test.js
+++ b/test/stream-util.test.js
@@ -25,6 +25,24 @@ test('putTileRetry fail=2, retry=2', function(assert) {
     });
 });
 
+test('putTileRetry fail=1, retry=0', function(assert) {
+    var source = new Timedsource({fail:1});
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 0, function(err) {
+        assert.equal(source.fails['0/0/0'], 1, 'failed x1');
+        assert.equal(err.toString(), 'Error: Fatal', 'passes error');
+        assert.end();
+    });
+});
+
+test('putTileRetry fail=0, retry=0', function(assert) {
+    var source = new Timedsource({fail:0});
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 0, function(err) {
+        assert.equal(source.fails['0/0/0'], undefined, 'failed x0');
+        assert.ifError(err, 'no error');
+        assert.end();
+    });
+});
+
 test('getTileRetry fail=2, retry=3', function(assert) {
     var source = new Timedsource({fail:2});
     util.getTileRetry(source, 0, 0, 0, 3, function(err, data, headers) {
@@ -41,6 +59,27 @@ test('getTileRetry fail=2, retry=2', function(assert) {
     util.getTileRetry(source, 0, 0, 0, 2, function(err, data, headers) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.equal(err.toString(), 'Error: Fatal', 'passes error');
+        assert.end();
+    });
+});
+
+
+test('getTileRetry fail=1, retry=0', function(assert) {
+    var source = new Timedsource({fail:1});
+    util.getTileRetry(source, 0, 0, 0, 0, function(err, data, headers) {
+        assert.equal(source.fails['0/0/0'], 1, 'failed x1');
+        assert.equal(err.toString(), 'Error: Fatal', 'passes error');
+        assert.end();
+    });
+});
+
+test('getTileRetry fail=0, retry=0', function(assert) {
+    var source = new Timedsource({fail:0});
+    util.getTileRetry(source, 0, 0, 0, 0, function(err, data, headers) {
+        assert.equal(source.fails['0/0/0'], undefined, 'failed x0');
+        assert.ifError(err, 'no error');
+        assert.equal(data instanceof Buffer, true, 'passes buffer');
+        assert.deepEqual(headers, {}, 'passes headers');
         assert.end();
     });
 });

--- a/test/stream-util.test.js
+++ b/test/stream-util.test.js
@@ -5,6 +5,45 @@ var fs = require('fs');
 var path = require('path');
 var util = require('../lib/stream-util');
 var assert = require('assert');
+var Timedsource = require('./timedsource');
+
+test('putTileRetry fail=2, retry=3', function(assert) {
+    var source = new Timedsource({fail:2});
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 3, function(err) {
+        assert.equal(source.fails['0/0/0'], 2, 'failed x2');
+        assert.ifError(err, 'no error');
+        assert.end();
+    });
+});
+
+test('putTileRetry fail=2, retry=2', function(assert) {
+    var source = new Timedsource({fail:2});
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 2, function(err) {
+        assert.equal(source.fails['0/0/0'], 2, 'failed x2');
+        assert.equal(err.toString(), 'Error: Fatal', 'passes error');
+        assert.end();
+    });
+});
+
+test('getTileRetry fail=2, retry=3', function(assert) {
+    var source = new Timedsource({fail:2});
+    util.getTileRetry(source, 0, 0, 0, 3, function(err, data, headers) {
+        assert.equal(source.fails['0/0/0'], 2, 'failed x2');
+        assert.ifError(err, 'no error');
+        assert.equal(data instanceof Buffer, true, 'passes buffer');
+        assert.deepEqual(headers, {}, 'passes headers');
+        assert.end();
+    });
+});
+
+test('getTileRetry fail=2, retry=2', function(assert) {
+    var source = new Timedsource({fail:2});
+    util.getTileRetry(source, 0, 0, 0, 2, function(err, data, headers) {
+        assert.equal(source.fails['0/0/0'], 2, 'failed x2');
+        assert.equal(err.toString(), 'Error: Fatal', 'passes error');
+        assert.end();
+    });
+});
 
 test('Tile: blank', function(t) {
     var tile;
@@ -136,3 +175,4 @@ test('Info: deserialize', function(t) {
         t.ok(valid, 'unparsable data throws expected exception');
     }
 });
+

--- a/test/stream-util.test.js
+++ b/test/stream-util.test.js
@@ -7,18 +7,23 @@ var util = require('../lib/stream-util');
 var assert = require('assert');
 var Timedsource = require('./timedsource');
 
-test('putTileRetry fail=2, retry=3', function(assert) {
+test('retryBackoff (setup)', function(assert) {
+    util.retryBackoff = 10;
+    assert.end();
+});
+
+test('putTileRetry fail=2, tries=2', function(assert) {
     var source = new Timedsource({fail:2});
-    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 3, function(err) {
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 2, function(err) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.ifError(err, 'no error');
         assert.end();
     });
 });
 
-test('putTileRetry fail=2, retry=2', function(assert) {
+test('putTileRetry fail=2, retry=1', function(assert) {
     var source = new Timedsource({fail:2});
-    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 2, function(err) {
+    util.putTileRetry(source, 0, 0, 0, new Buffer(0), 1, function(err) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.equal(err.toString(), 'Error: Fatal', 'passes error');
         assert.end();
@@ -43,9 +48,9 @@ test('putTileRetry fail=0, retry=0', function(assert) {
     });
 });
 
-test('getTileRetry fail=2, retry=3', function(assert) {
+test('getTileRetry fail=2, retry=2', function(assert) {
     var source = new Timedsource({fail:2});
-    util.getTileRetry(source, 0, 0, 0, 3, function(err, data, headers) {
+    util.getTileRetry(source, 0, 0, 0, 2, function(err, data, headers) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.ifError(err, 'no error');
         assert.equal(data instanceof Buffer, true, 'passes buffer');
@@ -54,9 +59,9 @@ test('getTileRetry fail=2, retry=3', function(assert) {
     });
 });
 
-test('getTileRetry fail=2, retry=2', function(assert) {
+test('getTileRetry fail=2, retry=1', function(assert) {
     var source = new Timedsource({fail:2});
-    util.getTileRetry(source, 0, 0, 0, 2, function(err, data, headers) {
+    util.getTileRetry(source, 0, 0, 0, 1, function(err, data, headers) {
         assert.equal(source.fails['0/0/0'], 2, 'failed x2');
         assert.equal(err.toString(), 'Error: Fatal', 'passes error');
         assert.end();
@@ -82,6 +87,11 @@ test('getTileRetry fail=0, retry=0', function(assert) {
         assert.deepEqual(headers, {}, 'passes headers');
         assert.end();
     });
+});
+
+test('retryBackoff (reset)', function(assert) {
+    util.retryBackoff = 1000;
+    assert.end();
 });
 
 test('Tile: blank', function(t) {


### PR DESCRIPTION
Adds retry option to the readable and writable tile streams with exponential backoff.

- [x] Expose retry option through to `tilelive.copy` method
- [x] Expose retry option through to tilelive-copy bin

@rclark will you need anything else here? Also,  **question:** should a retry option apply to both read/write streams or should there be seperate options to enable retry on each stream?
