### PR TITLE
Copy timeout

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -341,6 +341,7 @@ tilelive.copy = function(src, dst, options, callback) {
 
     q.await(function(err) {
         if (err) return callback(err);
+
         copy(src, dst, options, function(err) {
             if (err) return callback(err);
             if (options.close) closingTime(src, dst, function(err) {
@@ -352,12 +353,12 @@ tilelive.copy = function(src, dst, options, callback) {
     });
 
     function copy(src, dst, opts, callback) {
-        // copy to outStream, if present. This is done after the src is loaded
-        if (!dst && opts.outStream) return out(opts, callback);
+        // sinkStream represents a copy to a non-tilelive stream
+        var sinkStream = !dst && opts.outStream;
 
-        // Copy
         var get = tilelive.createReadStream(src, opts);
-        var put = tilelive.createWriteStream(dst, {retry:opts.retry});
+        var put = sinkStream ?
+            options.outStream : tilelive.createWriteStream(dst, {retry:opts.retry});
 
         var hasErrored = false;
         function handleError(err) {
@@ -365,46 +366,31 @@ tilelive.copy = function(src, dst, options, callback) {
             hasErrored = true;
         }
 
-        get.on('error', handleError);
-        put.on('error', handleError);
-        get.on('length', prog.setLength);
-        if (options.progress) prog.on('progress', function(p) { options.progress(get.stats, p); });
-
-        if (opts.type === 'list') {
-            var file = opts.listStream;
-            file.pipe(get).pipe(prog).pipe(put);
-        } else {
-            get.pipe(prog).pipe(put);
-        }
-
-        put.on('stop', callback);
-    }
-
-    function out(options, callback) {
-        var get = tilelive.createReadStream(src, options);
-        var put = options.outStream;
-
-        var hasErrored = false;
-        function handleError(err) {
-            if (!hasErrored) callback(err);
-            hasErrored = true;
-        }
+        var previous;
+        setInterval(function() {
+            if (prog.progress.transferred === previous) {
+                // kill somehow
+            }
+            previous = prog.progress.transferred;
+        }, 60000).unref();
 
         get.on('error', handleError);
         put.on('error', handleError);
         get.on('length', prog.setLength);
-        if (options.progress) prog.on('progress', function(p) { options.progress(get.stats, p); });
+
+        if (options.progress)
+            prog.on('progress', function(p) { options.progress(get.stats, p); });
+
+        var doneEvent = sinkStream ? 'finish' : 'stop';
 
         if (options.outStream === process.stdout ||
             options.outStream === process.stderr) prog.on('end', callback);
-        else put.on('finish', callback);
+        else
+            put.on(doneEvent, callback);
 
-        if (options.type === 'list') {
-            var file = options.listStream;
-            file.pipe(get).pipe(tilelive.serialize()).pipe(prog).pipe(put);
-        } else {
-            get.pipe(tilelive.serialize()).pipe(prog).pipe(put);
-        }
+        var pipeline = opts.type === 'list' ? opts.listStream.pipe(get) : get;
+        if (sinkStream) pipeline = pipeline.pipe(tilelive.serialize());
+        pipeline.pipe(prog).pipe(put);
     }
 
     function closingTime(src, dst, callback) {

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -342,7 +342,7 @@ tilelive.copy = function(src, dst, options, callback) {
     q.await(function(err) {
         if (err) return callback(err);
 
-        copy(src, dst, options, function(err) {
+            copy(src, dst, options, function(err) {
             if (err) return callback(err);
             if (options.close) closingTime(src, dst, function(err) {
                 if (err) throw err;
@@ -360,22 +360,28 @@ tilelive.copy = function(src, dst, options, callback) {
         var put = sinkStream ?
             options.outStream : tilelive.createWriteStream(dst, {retry:opts.retry});
 
-        var hasErrored = false;
-        function handleError(err) {
-            if (!hasErrored) callback(err);
-            hasErrored = true;
+        var sentCallback = false;
+        function done(err) {
+            if (!sentCallback) {
+                clearInterval(timeout);
+                callback(err);
+            }
+            sentCallback = true;
         }
 
         var previous;
-        setInterval(function() {
+        var timeout = setInterval(function() {
             if (prog.progress.transferred === previous) {
-                // kill somehow
+                done(new Error('Copy operation timed out'));
+                pipeline.unpipe(prog);
+                prog.end();
+                clearInterval(timeout);
             }
             previous = prog.progress.transferred;
-        }, 60000).unref();
+        }, opts.timeout || 60000);
 
-        get.on('error', handleError);
-        put.on('error', handleError);
+        get.on('error', done);
+        put.on('error', done);
         get.on('length', prog.setLength);
 
         if (options.progress)
@@ -384,9 +390,9 @@ tilelive.copy = function(src, dst, options, callback) {
         var doneEvent = sinkStream ? 'finish' : 'stop';
 
         if (options.outStream === process.stdout ||
-            options.outStream === process.stderr) prog.on('end', callback);
+            options.outStream === process.stderr) prog.on('end', done);
         else
-            put.on(doneEvent, callback);
+            put.on(doneEvent, done);
 
         var pipeline = opts.type === 'list' ? opts.listStream.pipe(get) : get;
         if (sinkStream) pipeline = pipeline.pipe(tilelive.serialize());

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -148,16 +148,16 @@ test('tilelive copy: missing liststream', function(t) {
 test('tilelive.copy: close src/dst', function(t) {
     var src = new Timedsource({});
     src.flag = false;
-    src.close = function(callback) { 
-        this.flag = true; 
-        callback(); 
+    src.close = function(callback) {
+        this.flag = true;
+        callback();
     };
 
     var dst = new Timedsource({});
     dst.flag = false;
-    dst.close = function(callback) { 
-        this.flag = true; 
-        callback(); 
+    dst.close = function(callback) {
+        this.flag = true;
+        callback();
     };
 
     var options = {
@@ -303,6 +303,17 @@ test('tilelive.copy + write err (retry)', function(t) {
         require('../lib/stream-util').retryBackoff = 1000;
         t.ifError(err);
         t.equal(src.fails['0/0/0'], 1, 'failed x1');
+        t.end();
+    });
+});
+
+test('tilelive.copy timeout', function(t) {
+    var src = new Timedsource({timeout: 1000});
+    var dst = new Timedsource({});
+    var options = { timeout: 1000, maxzoom: 21 };
+    tilelive.copy(src, dst, options, function(err) {
+        t.ok(err, 'expected error message');
+        t.equal(err.message, 'Copy operation timed out', 'timeout error');
         t.end();
     });
 });

--- a/test/stream-scanline.test.js
+++ b/test/stream-scanline.test.js
@@ -192,7 +192,7 @@ test('scanline: invalid extent', function(assert) {
     require('../lib/stream-util').retryBackoff = 1;
     var get = tilelive.createReadStream(fakesrc, {type:'scanline'});
     var put = tilelive.createWriteStream(new Timedsource({}));
-    get.on('error', function(err) {         
+    get.on('error', function(err) {
         assert.equal(err.message, 'bounds must be an array of the form [west, south, east, north]');
     });
     get.pipe(put);

--- a/test/timedsource.js
+++ b/test/timedsource.js
@@ -20,6 +20,13 @@ function Timedsource(uri, callback) {
     this.fail = uri.fail || 0;
     this.fails = {};
 
+    if (uri.timeout) {
+        var timedsource = this;
+        setTimeout(function() {
+            timedsource.hang = true;
+        }, uri.timeout);
+    }
+
     if (callback) callback(null, this);
     return this;
 }
@@ -45,6 +52,8 @@ Timedsource.prototype.getTile = function(z, x, y, callback) {
         fails[key] = fails[key] || 0;
     }
 
+    if (this.hang) return;
+    
     setTimeout(function() {
         if (fail && fails[key] < fail) {
             fails[key]++;


### PR DESCRIPTION
Adds a configuration option to `tilelive.copy` that allows you to specify a timeout value (in ms, defaults to 60000). If the progress-stream does not change in this period, the copy operation is halted and an error is thrown.

cc @yhahn 