### PR TITLE
Intermediate transform stream

### DIFF
--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -313,9 +313,9 @@ tilelive.copy = function(src, dst, options, callback) {
     }
     if (options.concurrency) tilelive.stream.setConcurrency(options.concurrency);
 
-    if (options.transform) {
-        if (!options.transform.write || !options.transform.read)
-            return callback(new Error('You must provide a valid transform stream'));
+    // if (options.transform && (!options.transform._write || !options.transform._read)) {
+    if (options.transform && !(options.transform instanceof stream.Transform)) {
+        return callback(new Error('You must provide a valid transform stream'));
     }
 
     var prog = progress({

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -313,6 +313,11 @@ tilelive.copy = function(src, dst, options, callback) {
     }
     if (options.concurrency) tilelive.stream.setConcurrency(options.concurrency);
 
+    if (options.transform) {
+        if (!options.transform.write || !options.transform.read)
+            return callback(new Error('You must provide a valid transform stream'));
+    }
+
     var prog = progress({
         objectMode: true,
         time: 100
@@ -395,6 +400,7 @@ tilelive.copy = function(src, dst, options, callback) {
             put.on(doneEvent, done);
 
         var pipeline = opts.type === 'list' ? opts.listStream.pipe(get) : get;
+        if (options.transform) pipeline = pipeline.pipe(options.transform);
         if (sinkStream) pipeline = pipeline.pipe(tilelive.serialize());
         pipeline.pipe(prog).pipe(put);
     }

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var fs = require('fs');
+var stream = require('stream');
 var tmp = require('os').tmpdir();
 var path = require('path');
 var exec = require('child_process').exec;
@@ -314,6 +315,24 @@ test('tilelive.copy timeout', function(t) {
     tilelive.copy(src, dst, options, function(err) {
         t.ok(err, 'expected error message');
         t.equal(err.message, 'Copy operation timed out', 'timeout error');
+        t.end();
+    });
+});
+
+test('tilelive.copy transform', function(t) {
+    var src = __dirname + '/fixtures/plain_1.mbtiles';
+    var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy.mbtiles');
+    var transform = new stream.Transform({ objectMode: true });
+    var count = 0;
+    transform._transform = function(tile, enc, callback) {
+        count++;
+        transform.push(tile);
+        callback();
+    };
+
+    tilelive.copy(src, dst, { transform: transform }, function(err){
+        t.ifError(err, 'success');
+        t.equal(count, 286, 'tiles were passed through transform stream');
         t.end();
     });
 });

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -337,6 +337,24 @@ test('tilelive.copy transform', function(t) {
     });
 });
 
+test('tilelive.copy not a transform', function(t) {
+    var src = __dirname + '/fixtures/plain_1.mbtiles';
+    var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy.mbtiles');
+    var transform = new stream.Writable({ objectMode: true });
+    var count = 0;
+    transform._write = function(tile, enc, callback) {
+        count++;
+        transform.push(tile);
+        callback();
+    };
+
+    tilelive.copy(src, dst, { transform: transform }, function(err){
+        t.equal(err.message, 'You must provide a valid transform stream', 'expected error');
+        t.equal(count, 0, 'no tiles were copied');
+        t.end();
+    });
+});
+
 // Used for progress report
 function report(stats, p) {
     util.print(util.format('\r\033[K[%s] %s%% %s/%s @ %s/s | ✓ %s □ %s | %s left',


### PR DESCRIPTION
Allows the caller of `tilelive.copy` to provide a transform stream. If provided, its inserted into the copy pipeline and could allow the caller to "spy" on the tiles as they are copied.

refs #130 #129 
cc @yhahn @tmcw 