### PR TITLE
Confirm that copy operation does not ALWAYS timeout at specified time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ node_js:
 script:
  - npm test
  - npm run cov
+
+sudo: false

--- a/lib/tilelive.js
+++ b/lib/tilelive.js
@@ -376,13 +376,14 @@ tilelive.copy = function(src, dst, options, callback) {
 
         var previous;
         var timeout = setInterval(function() {
-            if (prog.progress.transferred === previous) {
+            var current = prog.progress().transferred;
+            if (current === previous) {
                 done(new Error('Copy operation timed out'));
                 pipeline.unpipe(prog);
                 prog.end();
                 clearInterval(timeout);
             }
-            previous = prog.progress.transferred;
+            previous = current;
         }, opts.timeout || 60000);
 
         get.on('error', done);

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -319,6 +319,22 @@ test('tilelive.copy timeout', function(t) {
     });
 });
 
+test('tilelive.copy timeout does not always fail at timeout interval', function(t) {
+    var src = new Timedsource({timeout: 3000});
+    var dst = new Timedsource({});
+    var options = { timeout: 1000, maxzoom: 21 };
+    tilelive.copy(src, dst, options, done);
+
+    function done(err) {
+        if (done.finished) return;
+        t.ifError(err, 'should not error');
+        done.finished = true;
+        t.ok('kept copying past timeout');
+        t.end();
+    }
+    setTimeout(done, 2000);
+});
+
 test('tilelive.copy transform', function(t) {
     var src = __dirname + '/fixtures/plain_1.mbtiles';
     var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy.mbtiles');


### PR DESCRIPTION
A syntax error in `tilelive.copy` and loose tests meant that #128 **always** timed out at the specified interval.

Fixes the syntax error and adds a test for it.