### PR TITLE
Expose timeout copy option to command util

### DIFF
--- a/bin/tilelive-copy
+++ b/bin/tilelive-copy
@@ -29,6 +29,7 @@ if (!argv._[0]) {
     console.log('  --list=[filepath]                 Filepath if scheme is list.');
     console.log('  --concurrency=[number]            Copy concurrency.');
     console.log('  --withoutprogress                 Shows progress by default.');
+    console.log('  --timeout=[number]                Timeout after n ms of inactivity.');
     console.log('  --bounds=[w,s,e,n]');
     console.log('  --minzoom=[number]');
     console.log('  --maxzoom=[number]');
@@ -48,6 +49,7 @@ argv.withoutprogress = argv.withoutprogress ? true : false;
 argv.parts = isNumeric(argv.parts) ? argv.parts : undefined;
 argv.part = isNumeric(argv.part) ? argv.part : undefined;
 argv.retry = isNumeric(argv.retry) ? parseInt(argv.retry,10) : undefined;
+argv.timeout = isNumeric(argv.timeout) ? parseInt(argv.timeout,10) : undefined;
 
 if (argv.scheme !== 'pyramid' && argv.scheme !== 'scanline' && argv.scheme !== 'list') {
     console.warn('scheme must be one of pyramid, scanline, list');
@@ -74,6 +76,7 @@ function copy() {
         maxzoom:argv.maxzoom,
         bounds:argv.bounds,
         retry:argv.retry,
+        timeout:argv.timeout,
         close:true
     };
     

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -88,6 +88,14 @@ test('copy part zero', function(t) {
     });
 });
 
+test('copy timeout', function(t) {
+    exec(__dirname + '/../bin/tilelive-copy ' + __dirname + '/fixtures/plain_1.mbtiles --timeout=1', function(err, stdout, stderr) {
+        t.ok(err);
+        t.ok(/Copy operation timed out/.test(stderr));
+        t.end();
+    });
+});
+
 test('tilelive.copy', function(t) {
     var src = __dirname + '/fixtures/plain_1.mbtiles';
     var dst = path.join(tmp, crypto.randomBytes(12).toString('hex') + '.tilelivecopy.mbtiles');


### PR DESCRIPTION
Adds `--timeout` flag for https://github.com/mapbox/tilelive.js/pull/128 to `tilelive-copy`.