### PR TITLE
Make implicit API expectation explicit

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,6 +12,9 @@ Tilesource.prototype.getTile = function(z, x, y, callback) {
     // obtains tile and calls callback:
     function(err, tile, options) {
         // err is set when the tile does not exist or when retrieval failed.
+        // If the tile does not exist and that's OK, the error message should
+        // explicitly read 'Tile does not exist' in order to be handled correctly
+        // by tilelive.copy.
         // otherwise, tile is a buffer containing the compressed image data
     }
 };


### PR DESCRIPTION
I was bitten by issue #42 when trying to implement a tilelive TileSource that used vector tiles, which by their nature are sparse. (My backend would faithfully emit error messages for missing tiles, but with a different wording which made tilelive crash out rather than just skip the tile.) Until the actual issue is resolved (which would mean bumping the API version and rewriting all tilelive implementations, I guess) it should be made an explicit part or the API doc.

